### PR TITLE
Release/v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,9 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          # Personal Access Token with write access to homebrew-tap repo.
+          # Create at: GitHub → Settings → Developer settings → PATs (classic)
+          # Scopes needed: repo (full)
+          # Then add as repo secret: Settings → Secrets → Actions → HOMEBREW_TAP_TOKEN
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SCOOP_TAP_TOKEN: ${{ secrets.SCOOP_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,12 +15,16 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     binary: vex
     ldflags:
       - -s -w -X main.version={{.Version}}
 
 archives:
   - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
         format: zip
@@ -30,30 +34,66 @@ archives:
       - CHANGELOG.md
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+  groups:
+    - title: "New Features"
+      regexp: "^feat"
+      order: 0
+    - title: "Bug Fixes"
+      regexp: "^fix"
+      order: 1
+    - title: "Other"
+      order: 999
 
 brews:
   - name: vex
     homepage: "https://github.com/CodeOne45/vex-tui"
-    description: "Beautiful terminal Excel and CSV viewer with vim-style keybindings"
+    description: "Beautiful terminal Excel and CSV viewer & editor with vim-style keybindings"
     license: "MIT"
 
+    # Only upload when the token secret is available
     skip_upload: "{{ if .Env.HOMEBREW_TAP_TOKEN }}false{{ else }}true{{ end }}"
 
     repository:
       owner: CodeOne45
       name: homebrew-tap
+      branch: main
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      pull_request:
+        enabled: false
+
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
 
     install: |
       bin.install "vex"
+
+    test: |
+      system "#{bin}/vex", "--version"
+
+scoops:
+  - name: vex
+    homepage: "https://github.com/CodeOne45/vex-tui"
+    description: "Beautiful terminal Excel and CSV viewer & editor with vim-style keybindings"
+    license: "MIT"
+    skip_upload: "{{ if .Env.SCOOP_TAP_TOKEN }}false{{ else }}true{{ end }}"
+    repository:
+      owner: CodeOne45
+      name: scoop-bucket
+      token: "{{ .Env.SCOOP_TAP_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,73 @@ All notable changes to Vex will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-04-17
+
+### Added
+
+#### Row Filter (`f`)
+- Press `f` to filter rows on the current column or all columns (Tab toggles scope)
+- Supports plain text (contains), `>`, `<`, `>=`, `<=`, `=` expressions for numeric and exact-match comparisons
+- Active filter shown in the title bar as `▾ <expr>`; **Esc** clears it without touching the underlying data
+
+#### Data Profile (`W`)
+- New modal showing a per-column breakdown: detected type (number / text / mixed), non-null count, null count
+- Numeric columns show Σ / avg / min / max inline; text columns show unique count and top sample values
+- Highlights the column currently under the cursor
+
+#### Sort Columns (`s` / `S` / `u`)
+- `s` sorts the current column ascending, `S` descending
+- `u` restores the original row order (pre-sort state is saved in memory)
+- Sort indicator shown in the column header and title bar; freeze-header aware
+
+#### Freeze Header Row (`Ctrl+R`)
+- Toggles the first row pinned at all times while scrolling
+- A divider line separates the frozen row from scrollable data
+- `⌶` indicator in title bar; sort respects the frozen header
+
+#### Live Column Statistics
+- When the cursor is on any numeric column, the status bar automatically shows Σ / avg / min / max / n
+- No selection needed; updates as you navigate
+
+#### Chart PNG Export (`p` in chart view)
+- Press `p` inside the chart modal to export the current chart as a beautiful PNG via [`freeze`](https://github.com/charmbracelet/freeze)
+- Output file is `<filename>-chart.png` saved next to the source file
+- If `freeze` is not on PATH the binary is located across all common Homebrew and Linux install paths automatically
+- If still not found, shows the exact install command as a status bar hint
+
+#### CSV Delimiter Auto-Detection + CLI Flag
+- Vex reads the first line of every CSV and picks the best delimiter from `,` `;` `\t` `|`
+- New `-d` / `--delimiter` flag for explicit override: `vex data.csv -d ';'`, `vex data.tsv -d '\t'`
+
+### Changed
+
+#### UI / UX
+- **Cell type coloring**: numbers render in accent color, formulas in secondary color, text in default — no configuration needed
+- **Status bar redesign**: left cluster (cell ref + dimensions + mode flags), middle cluster (column stats or selection size), right cluster (search + status message)
+- **Title bar**: `●` modified indicator appears immediately on first edit; freeze / sort / filter state shown as compact glyphs
+- **Selection highlight**: uses primary color background, much more visible than before
+- **Responsive modals**: theme picker and chart modal now scale to terminal width/height instead of hardcoded sizes
+- **Chart bar chart**: supports negative values (shown in red), `░` unfilled track, cleaner value labels
+- **Chart line chart**: Bresenham algorithm draws actual connecting lines (`·`) between data points (`●`)
+- **Chart data extraction**: auto-detects label vs value columns — works with or without a leading text column
+- **Chart type tabs**: rendered as proper tab buttons instead of a plain list
+
+#### Keybinding Changes
+- `f` — now opens row filter (was: toggle formula display)
+- `ctrl+f` — toggle formula display (moved from `f`)
+- `W` — data profile
+- `s` / `S` / `u` — sort asc / desc / unsort
+- `ctrl+r` — freeze header
+
+#### Release Workflow
+- GoReleaser config: grouped changelog, `test` stanza in Homebrew formula, Scoop bucket support
+- `Makefile`: `make tag VER=v2.1.0` tags and pushes, triggering the full CI/release pipeline; `make snapshot` for local multi-platform builds
+
+### Fixed
+
+- **Esc cancels selection**: pressing Esc in normal mode while a range is selected now cancels it (previously Esc only cleared search)
+- **Freeze binary lookup**: `freeze` is located across PATH, all Homebrew symlink paths, and the Cellar directly — fixing "not found" errors when the Homebrew symlink is broken
+
 ## [2.0.2] - 2025-02-13
 
 ### Fixed
@@ -263,6 +330,7 @@ This is a major release that transforms Vex from a viewer into a full-featured t
 - Vim-style navigation
 - Multiple sheet support
 
+[2.1.0]: https://github.com/CodeOne45/vex-tui/releases/tag/v2.1.0
 [2.0.2]: https://github.com/CodeOne45/vex-tui/releases/tag/v2.0.2
 [2.0.1]: https://github.com/CodeOne45/vex-tui/releases/tag/v2.0.1
 [2.0.0]: https://github.com/CodeOne45/vex-tui/releases/tag/v2.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build run clean install test lint fmt help release
 
 BINARY_NAME=vex
-VERSION=2.0.2
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "2.0.2")
 BUILD_DIR=dist
 GO_FILES=$(shell find . -name '*.go' -type f)
 
@@ -78,6 +78,18 @@ release: clean
 	@GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X main.version=$(VERSION)" -trimpath -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe .
 	@cd $(BUILD_DIR) && sha256sum * > checksums.txt
 	@echo "Release builds created in $(BUILD_DIR)/"
+
+# Tag and push a new release — triggers GitHub Actions to build + publish
+# Usage: make tag VER=v2.1.0
+tag:
+	@if [ -z "$(VER)" ]; then echo "Usage: make tag VER=v2.1.0"; exit 1; fi
+	git tag -a $(VER) -m "Release $(VER)"
+	git push origin $(VER)
+	@echo "✓ Tag $(VER) pushed — GitHub Actions will build and publish automatically."
+
+# Build a local snapshot with goreleaser (no publish)
+snapshot:
+	goreleaser release --snapshot --clean
 
 # Security audit
 audit:

--- a/README.md
+++ b/README.md
@@ -1,398 +1,413 @@
-# 📊 Vex - Terminal Spreadsheet Editor
+# 📊 Vex — Terminal Spreadsheet Editor
 
-A beautiful, fast, and feature-rich terminal-based Excel and CSV editor with vim-style keybindings and formula support.
+A beautiful, fast, and feature-rich terminal-based Excel and CSV editor with vim-style keybindings, live row filtering, instant data profiling, formula support, and chart export.
 
 [![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)](https://golang.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.2-brightgreen.svg)](https://github.com/CodeOne45/vex-tui/releases)
+[![Version](https://img.shields.io/badge/version-2.1.0-brightgreen.svg)](https://github.com/CodeOne45/vex-tui/releases)
+[![Stars](https://img.shields.io/github/stars/CodeOne45/vex-tui?style=flat&color=yellow)](https://github.com/CodeOne45/vex-tui/stargazers)
+
+<a href="https://www.buymeacoffee.com/CodeOne45" target="_blank">
+  <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="40">
+</a>
 
 ![Vex Demo](assets/vex-demo.gif)
 
+---
+
 ## ✨ Features
+
+### 🔍 Live Row Filtering
+
+Press `f` to filter any dataset without leaving the keyboard:
+
+```
+f  →  type expression  →  Enter to apply  •  Esc to clear
+```
+
+| Expression | Matches |
+|---|---|
+| `apple` | rows containing "apple" (case-insensitive) |
+| `>1000` | rows where current column > 1000 |
+| `<=50.5` | rows where current column ≤ 50.5 |
+| `=Canada` | exact match (text or number) |
+
+- **Tab** while typing toggles between current column and all columns
+- Active filter shown in the title bar as `▾ >1000`
+- **Esc** clears the filter instantly — original data is always preserved in memory
+- Works on any column of any CSV or Excel file
+
+### 📊 Data Profile
+
+Press `W` to get a full column-by-column breakdown of any dataset — like `pandas.describe()` right in your terminal:
+
+```
+  Col   Type      Non-null  Nulls   Stats
+  A     number    1,234     0       Σ 2.4M  avg 1.9K  [0 – 9,999]
+  B     text      1,230     4       891 unique  Alice, Bob, Carol…
+  C     mixed     800       200     200 nulls, some numbers
+```
+
+- Auto-detects column types: number, text, mixed
+- Shows non-null count, null count, unique values for text columns
+- Shows Σ / avg / min / max for numeric columns
+- Highlights the column currently under your cursor
+
+### ↕️ Sort Columns
+
+- `s` — sort current column **ascending**
+- `S` — sort current column **descending**
+- `u` — **unsort** — restore original row order
+
+Sort indicator shown in the column header (`A↑`) and in the title bar.
+Numeric and text columns are sorted with the appropriate comparison.
+When freeze header is enabled, the header row stays pinned during sort.
+
+### ⌶ Freeze Header Row
+
+Press `Ctrl+R` to pin the first row permanently at the top while scrolling through large files. The `⌶` indicator appears in the title bar when active. Sort is freeze-header aware — the header row is never moved.
+
+### 📈 Live Column Statistics
+
+When the cursor is on any numeric column the status bar automatically shows:
+
+```
+Σ 45,230  avg 1,004  min 2  max 9,999  n=45
+```
+
+No selection required — just move your cursor.
+
+### 📁 CSV — Any Delimiter, Auto-Detected
+
+Vex reads the first line of every CSV file and picks the most likely delimiter from `,` `;` `\t` `|` automatically. You can also specify it explicitly:
+
+```bash
+vex data.csv                   # auto-detect
+vex data.csv -d ';'            # semicolon
+vex data.tsv -d '\t'           # tab
+vex data.csv --delimiter '|'   # pipe
+```
+
+### 📊 Data Visualization with Chart Export
+
+Select a range with `V`, then press `v` to open the chart viewer:
+
+- **Bar chart** — supports negative values, responsive width, unfilled track
+- **Line chart** — Bresenham algorithm draws actual connecting lines between points
+- **Sparkline** — compact inline overview + bar chart
+- **Pie chart** — proportional breakdown with legend
+
+Press `p` inside the chart to export a beautiful PNG image via [`freeze`](https://github.com/charmbracelet/freeze):
+
+```
+p  →  saves data-chart.png next to your file
+```
+
+If `freeze` is not installed, vex shows the install command. No other terminal spreadsheet lets you share charts as images.
 
 ### 🎨 Ten Beautiful Themes
 
+Press `t` to switch theme live. All themes are 256-color and truecolor compatible.
+
 **Dark Themes:**
-- **Catppuccin Mocha** - Soft pastels, perfect for all-day use
-- **Nord** - Cool Arctic blues, minimal and focused
-- **Rosé Pine** - Elegant rose tones, sophisticated
-- **Tokyo Night** - Vibrant cyberpunk aesthetic
-- **Gruvbox** - Warm retro colors, comfortable
-- **Dracula** - Classic high contrast theme
+- **Catppuccin Mocha** — Soft pastels, perfect for all-day use
+- **Nord** — Cool Arctic blues, minimal and focused
+- **Rosé Pine** — Elegant rose tones, sophisticated
+- **Tokyo Night** — Vibrant cyberpunk aesthetic
+- **Gruvbox** — Warm retro colors, comfortable
+- **Dracula** — Classic high contrast theme
 
 **Light Themes:**
-- **Catppuccin Latte** - Gentle pastel light theme
-- **Solarized Light** - Balanced contrast
-- **GitHub Light** - Clean and minimal
-- **One Light** - Soft Atom-inspired colors
+- **Catppuccin Latte** — Gentle pastel light theme
+- **Solarized Light** — Balanced contrast
+- **GitHub Light** — Clean and minimal
+- **One Light** — Soft Atom-inspired colors
+
+### 🎨 Cell Type Coloring
+
+Numbers, formulas, and text are visually distinct — no configuration needed:
+- **Numbers** — accent color, easy to scan down columns
+- **Formulas** — secondary color, instantly recognizable
+- **Text** — default theme color
 
 ### ✏️ Full Editing Capabilities
 
-- **Edit cells** with formulas and values
-- **Insert/delete** rows and columns
-- **Copy/paste** single cells or ranges
-- **Fill down/right** for quick data entry
+- **Edit cells** with values or formulas (`i`)
+- **Insert / delete** rows and columns
+- **Copy / paste** single cells or multi-cell ranges (Tab-separated from any app)
+- **Fill down / right** for quick data entry
 - **Apply formulas** to entire ranges with automatic reference adjustment
-- **Auto-save** with modification tracking
-- **Undo-friendly** workflow with clear status messages
+- **Modification indicator** (`●`) in the title bar on first edit
+- `Tab` / `Shift+Tab` in edit mode saves and jumps to the next/previous cell
 
 ### 📐 Powerful Formula Engine
 
-**Arithmetic:** `=A1+B1`, `=C1*2`, `=D1/E1-F1`
+**Arithmetic:** `=A1+B1`, `=C1*D1/E1`, `=B2-B1`
 
-**15+ Built-in Functions:**
-- `SUM(A1:A10)` - Sum range
-- `AVERAGE(B1:B20)` / `AVG(...)` - Average values
-- `COUNT(C1:C50)` - Count numbers
-- `MAX(D1:D100)` / `MIN(...)` - Find max/min
-- `IF(A1>100, "High", "Low")` - Conditional logic
-- `CONCATENATE(A1, " ", B1)` / `CONCAT(...)` - Join text
-- `UPPER(A1)` / `LOWER(A1)` - Change case
-- `LEN(A1)` - Text length
-- `ROUND(A1, 2)` - Round numbers
-- `ABS(A1)` - Absolute value
-- `SQRT(A1)` - Square root
-- `POWER(2, 8)` / `POW(...)` - Exponentiation
+**15+ built-in functions:**
 
-**Auto-recalculation** when cells change
+| Function | Description |
+|---|---|
+| `SUM(A1:A10)` | Sum a range |
+| `AVERAGE(B1:B20)` / `AVG(...)` | Average values |
+| `COUNT(C1:C50)` | Count numbers |
+| `MAX(D1:D100)` / `MIN(...)` | Find extremes |
+| `IF(A1>100,"High","Low")` | Conditional logic |
+| `CONCAT(A1," ",B1)` / `CONCATENATE(...)` | Join text |
+| `UPPER(A1)` / `LOWER(A1)` | Change case |
+| `LEN(A1)` | Text length |
+| `ROUND(A1,2)` | Round to decimals |
+| `ABS(A1)` / `SQRT(A1)` / `POWER(2,8)` | Math functions |
+
+Auto-recalculates on every edit. Formula references auto-adjust when applied to a range.
 
 ### 🔍 Powerful Navigation
 
-- **Vim-style keybindings** (hjkl) and arrow keys
-- **Jump to cell** (Ctrl+G) - supports `A100`, `500`, or `10,5` formats
-- **Search** (/) across cells and formulas
-- **Navigate results** (n/N)
-- **Page Up/Down**, Home/End
-- **Multi-sheet** support with Tab navigation
+- **Vim-style keybindings** (`hjkl`) and arrow keys
+- **Jump to cell** (`Ctrl+G`) — supports `A100`, `500`, or `10,5`
+- **Search** (`/`) across cell values and formulas with `n`/`N` navigation
+- **Page Up/Down**, `Home`/`End`, `gg`/`G`
+- **Multi-sheet** support with `Tab` / `Shift+Tab`
 
 ### 📋 Data Operations
 
-- **Copy** cell (c) or entire row (C)
-- **Paste** (p) with multi-cell support
-- **Export** to CSV or JSON
-- **Save** (Ctrl+S) with format preservation
-- **Save As** (Ctrl+Shift+S) to new file
-- **Toggle formula display** (f)
-- **View cell details** (Enter)
-
-### 📊 Live Data Visualization
-
-- **Bar charts** - Compare values visually
-- **Line charts** - Show trends over time
-- **Sparklines** - Compact inline charts
-- **Pie charts** - Display proportions
-
-**How to use:**
-1. Press `V` to start range selection
-2. Move cursor and press `V` again
-3. Press `v` to open visualization
-4. Press 1-4 to switch chart types
+- **Copy** cell (`c`) or entire row (`C`) to clipboard
+- **Paste** (`p`) — multi-row/column paste from any app
+- **Export** (`e`) to CSV or JSON
+- **Save** (`Ctrl+S`) with format preservation (xlsx / csv)
+- **Save As** (`Ctrl+Shift+S`) to a new file
+- **Toggle formula display** (`Ctrl+F`)
+- **View cell details** (`Enter`) — full value, formula, and type
 
 ### 📑 File Support
 
-- **Excel files** (.xlsx, .xlsm, .xls) with formula preservation
-- **CSV files** with formula support (saved as text)
+- **Excel** (.xlsx, .xlsm, .xls) — full formula and multi-sheet support
+- **CSV** — auto-delimiter detection, any separator
 - **Multiple sheets** with easy navigation
-- **Large file optimization** with lazy loading
-- **Safe saving** with backup on errors
+- **Safe saving** — file format preserved on save
+
+---
 
 ## 🚀 Installation
 
-### Using Homebrew (macOS/Linux)
+### Homebrew (macOS / Linux) — recommended
 
 ```bash
 brew install CodeOne45/tap/vex
 ```
 
-### Using go install
+### go install
 
 ```bash
 go install github.com/CodeOne45/vex-tui@latest
 ```
 
-### Download Binary
+### Download binary
 
-Download pre-built binaries from the [releases page](https://github.com/CodeOne45/vex-tui/releases).
-
-**Available for:**
+Pre-built binaries on the [releases page](https://github.com/CodeOne45/vex-tui/releases):
 - macOS (Intel & Apple Silicon)
 - Linux (x64 & ARM64)
 - Windows (x64)
 
-### Build from Source
+### Build from source
 
 ```bash
-# Clone the repository
 git clone https://github.com/CodeOne45/vex-tui.git
 cd vex-tui
-
-# Install dependencies
-go mod download
-
-# Build
-go build -o vex .
-
-# Optional: Install globally
+make build
 sudo mv vex /usr/local/bin/
 ```
+
+---
 
 ## 📖 Usage
 
 ```bash
-# View a file (read-only until you press 'i')
-vex data.xlsx
-
-# Start with a specific theme
-vex report.csv --theme nord
-
-# Create new file (will be created on first save)
-vex newfile.xlsx
+vex data.xlsx                    # open Excel file
+vex report.csv                   # open CSV (delimiter auto-detected)
+vex data.csv -d ';'              # explicit semicolon delimiter
+vex data.tsv -d '\t'             # tab-separated
+vex file.xlsx --theme nord       # start with a specific theme
+vex --help                       # show all options
 ```
+
+---
 
 ## ⌨️ Keyboard Shortcuts
 
 ### Navigation
 
-- `↑↓←→` or `hjkl` - Navigate cells
-- `Page Up/Down` or `Ctrl+U/D` - Scroll by page
-- `Home/End` or `0/$` - First/last column
-- `g/G` - First/last column
-- `Tab/Shift+Tab` - Next/previous sheet
-- `Ctrl+G` - Jump to specific cell
+| Key | Action |
+|---|---|
+| `↑↓←→` / `hjkl` | Move cursor |
+| `PgUp` / `PgDn` or `Ctrl+U/D` | Scroll page |
+| `Home` / `End` or `0` / `$` | First / last column |
+| `gg` / `G` | Top / bottom of file |
+| `Tab` / `Shift+Tab` | Next / previous sheet |
+| `Ctrl+G` | Jump to cell (`A100`, `500`, `10,5`) |
+
+### Data & Analysis
+
+| Key | Action |
+|---|---|
+| `f` | Filter rows — `>100`, `<=50`, `=exact`, `text` |
+| `W` | Data profile — types, nulls, unique counts, stats |
+| `s` / `S` | Sort column ascending / descending |
+| `u` | Unsort — restore original order |
+| `Ctrl+R` | Toggle freeze header row |
+| `/` | Search cells and formulas |
+| `n` / `N` | Next / previous search result |
+| `Esc` | Clear filter / search / selection |
 
 ### Editing
 
-- `i` - Enter edit mode
-- `Enter` - Commit changes (in edit) / View details (in normal)
-- `Tab` - Save and move right (in edit mode)
-- `Shift+Tab` - Save and move left (in edit mode)
-- `Esc` - Cancel editing
-- `x` - Delete cell content
-- `dd` - Delete current row
-- `dc` - Delete current column
+| Key | Action |
+|---|---|
+| `i` | Enter edit mode |
+| `Tab` / `Shift+Tab` | Save and move right / left |
+| `Ctrl+S` | Save file |
+| `Esc` | Cancel edit |
+| `x` | Delete cell content |
+| `dd` / `dc` | Delete row / column |
+| `o` / `O` | Insert row / column |
+| `c` / `C` | Copy cell / row |
+| `p` | Paste |
+| `Ctrl+J` / `Ctrl+L` | Fill down / right (requires selection) |
+| `Ctrl+A` | Apply formula to range (requires selection) |
 
-### Cell Operations
+### View
 
-- `c` - Copy cell
-- `C` - Copy entire row
-- `p` - Paste
-- `o` - Insert row below
-- `O` - Insert column right
-- `Ctrl+J` - Fill down (requires selection)
-- `Ctrl+L` - Fill right (requires selection)
-- `Ctrl+A` - Apply formula to range (requires selection)
+| Key | Action |
+|---|---|
+| `>` / `<` | Widen / narrow column |
+| `Ctrl+F` | Toggle formula display |
+| `t` | Change theme |
+| `?` | Toggle help |
 
-### File Operations
+### Visualization
 
-- `Ctrl+S` - Save file
-- `Ctrl+Shift+S` - Save as
-- `e` - Export to CSV/JSON
-- `q` - Quit (press twice if unsaved changes)
+| Key | Action |
+|---|---|
+| `V` | Start / finish range selection |
+| `v` | Open chart (requires selection) |
+| `1` / `2` / `3` / `4` | Bar / Line / Sparkline / Pie |
+| `p` | Export chart as PNG image (inside chart view) |
 
-### Search & Navigation
+### File
 
-- `/` - Search
-- `n/N` - Next/previous search result
-- `Esc` - Clear search
+| Key | Action |
+|---|---|
+| `Ctrl+S` | Save |
+| `Ctrl+Shift+S` | Save as |
+| `e` | Export to CSV or JSON |
+| `q` | Quit (press twice if unsaved) |
 
-### Visualization & Display
+---
 
-- `V` - Start/finish range selection
-- `v` - Open visualization (after selection)
-- `1-4` - Switch chart types (in viz mode)
-- `f` - Toggle formula display
-- `t` - Change theme
-- `?` - Toggle help
+## 💡 Quick Start
 
-## 💡 Quick Start Guide
-
-### Viewing a File
-
-```bash
-vex mydata.xlsx
-# Navigate with arrow keys or hjkl
-# Press 'f' to toggle formula view
-# Press 't' to change theme
-```
-
-### Editing Data
+### Explore an unknown CSV
 
 ```bash
-# 1. Open file
-vex mydata.xlsx
-
-# 2. Navigate to a cell
-# 3. Press 'i' to edit
-# 4. Type value or formula: =SUM(A1:A10)
-# 5. Press Enter to save
-# 6. Press Ctrl+S to save file
+vex data.csv
+# W  → see column types, nulls, unique counts instantly
+# f  → type >1000 to show only matching rows
+# s  → sort the column under cursor
+# u  → restore original order
 ```
 
-### Working with Formulas
+### Visualize and export a chart
 
-```bash
-# Create a formula
-Press 'i' on cell C1
-Type: =A1+B1
-Press Enter
-
-# Apply to entire column
-Press 'V' to start selection at C1
-Move to C10 and press 'V'
-Move back to C1
-Press Ctrl+A to apply formula
-# Result: C1=A1+B1, C2=A2+B2, C3=A3+B3, etc.
+```
+1. Press V  — start range selection
+2. Move to end of data, press V  — finish selection
+3. Press v  — open chart
+4. Press 1-4  — switch chart type
+5. Press p  — save as PNG (requires freeze: brew install charmbracelet/tap/freeze)
 ```
 
-### Bulk Data Entry
+### Bulk formula entry
 
-```bash
-Press 'i' to start editing
-Type value and press Tab
-Continue typing in next cell
-Press Tab to keep moving right
-Press Ctrl+S when done
 ```
+i             Enter edit mode
+=A1*B1        Type formula
+Tab           Save and move right
+...           Continue typing
+Ctrl+S        Save file
+```
+
+Or: enter one formula → select range with `V` → press `Ctrl+A` to apply with auto-adjusted references.
+
+---
 
 ## 🏗️ Project Structure
 
 ```
 vex-tui/
-├── main.go                    # Application entry point
+├── main.go                     # Entry point + CLI flags
 ├── internal/
 │   ├── app/
-│   │   ├── model.go          # State management
-│   │   ├── update.go         # Event handling
-│   │   ├── view.go           # Rendering logic
-│   │   ├── keys.go           # Keybindings
-│   │   ├── edit.go           # Edit operations
-│   │   └── formulas.go       # Formula evaluation engine
+│   │   ├── model.go            # State + filter/sort/stats logic
+│   │   ├── update.go           # Event handling
+│   │   ├── view.go             # Rendering, charts, data profile
+│   │   ├── keys.go             # Keybindings
+│   │   ├── edit.go             # Edit / save operations
+│   │   └── formulas.go         # Formula evaluation engine
 │   ├── loader/
-│   │   ├── loader.go         # File loading
-│   │   └── save.go           # File saving
+│   │   ├── loader.go           # File loading + CSV delimiter detection
+│   │   └── save.go             # File saving
 │   ├── theme/
-│   │   └── theme.go          # Theme definitions
+│   │   └── theme.go            # Theme definitions
 │   └── ui/
-│       └── ui.go             # UI utilities
+│       └── ui.go               # Styles + helpers
 └── pkg/
     └── models/
-        └── models.go         # Data models
+        └── models.go           # Data models + mode constants
 ```
+
+---
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-### Development Setup
+Contributions are welcome! Please open an issue first for large changes.
 
 ```bash
 git clone https://github.com/CodeOne45/vex-tui.git
 cd vex-tui
-
-# Install dependencies
-make deps
-
-# Run tests
-make test
-
-# Build
-make build
-
-# Run with sample data
-make run
+make test            # run tests
+make build           # build binary
+make snapshot        # local multi-platform build via goreleaser
+make tag VER=v2.1.0  # tag + push → triggers GitHub Actions release
 ```
 
-### Code Style
+Follow [Effective Go](https://golang.org/doc/effective_go.html) and run `make fmt` before opening a PR.
 
-- Run `make fmt` before committing
-- Follow [Effective Go](https://golang.org/doc/effective_go.html) guidelines
-- Add tests for new features
-- Update documentation
+---
 
-## 📊 Examples
+## ☕ Support
 
-### Sales Report with Formulas
+If Vex saves you time or you just enjoy using it:
 
-```
-     A        B        C          D
-1  Item     Price    Qty      Total
-2  Apples   1.50     10      =B2*C2
-3  Oranges  2.00     5       =B3*C3
-4  Total    -        -       =SUM(D2:D3)
-```
+<a href="https://www.buymeacoffee.com/CodeOne45" target="_blank">
+  <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="50">
+</a>
 
-Select D2:D4, cursor on D2, press Ctrl+A to apply formula pattern.
+Every coffee keeps the terminal dream alive. ☕
 
-### Conditional Formatting (Formula-based)
-
-```
-     A           B
-1  Score    Grade
-2  85       =IF(A2>=90,"A",IF(A2>=80,"B","C"))
-```
-
-Apply to B2:B20 with Ctrl+A for instant grading.
-
-### Data Summary
-
-```
-     A              B
-1  Sales         1000
-2  Costs          600
-3  Profit      =A1-A2
-4  Margin      =ROUND(A3/A1*100,2)
-```
-
-## 🔧 Advanced Features
-
-### Formula Auto-adjustment
-
-When you apply a formula to a range, cell references automatically adjust:
-
-```
-Source: A1 contains =B1+C1
-
-Apply to A1:A5:
-  A1: =B1+C1
-  A2: =B2+C2
-  A3: =B3+C3
-  A4: =B4+C4
-  A5: =B5+C5
-```
-
-### Multi-cell Paste
-
-Copy ranges from other apps and paste into Vex:
-- Tab-separated values paste as multiple columns
-- Newline-separated values paste as multiple rows
-- Formulas (starting with =) are preserved
-
-### Keyboard-driven Workflow
-
-```
-i          Enter edit mode
-Type data  
-Tab        Save and move to next cell
-Tab        Continue entering data
-Tab        Keep going...
-Ctrl+S     Save entire file
-```
+---
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT — see [LICENSE](LICENSE).
 
 ## 🙏 Acknowledgments
 
-- Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea) TUI framework
-- Styled with [Lipgloss](https://github.com/charmbracelet/lipgloss)
-- Excel parsing by [Excelize](https://github.com/xuri/excelize)
-- Clipboard by [atotto/clipboard](https://github.com/atotto/clipboard)
+- [Bubble Tea](https://github.com/charmbracelet/bubbletea) — TUI framework
+- [Lipgloss](https://github.com/charmbracelet/lipgloss) — terminal styling
+- [Freeze](https://github.com/charmbracelet/freeze) — chart PNG export
+- [Excelize](https://github.com/xuri/excelize) — Excel parsing
+- [atotto/clipboard](https://github.com/atotto/clipboard) — clipboard support
 - Themes inspired by [Catppuccin](https://github.com/catppuccin/catppuccin), [Nord](https://www.nordtheme.com/), [Rosé Pine](https://rosepinetheme.com/), and others
-
-## 🔒 Security
-
-If you discover a security vulnerability, please create a private security advisory on GitHub or email the maintainers.
 
 ## 📮 Contact
 
@@ -400,10 +415,8 @@ If you discover a security vulnerability, please create a private security advis
 - **Issues**: [GitHub Issues](https://github.com/CodeOne45/vex-tui/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/CodeOne45/vex-tui/discussions)
 
-## ⭐ Star History
-
-If you find Vex useful, please consider giving it a star on GitHub!
-
 ---
 
-Made with ❤️ for terminal enthusiasts and spreadsheet power users everywhere.
+⭐ If Vex is useful to you, a star goes a long way — thank you!
+
+*Made with ❤️ for terminal enthusiasts and spreadsheet power users.*

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -47,6 +47,12 @@ type KeyMap struct {
 	ApplyFormula key.Binding
 	ColWidthInc  key.Binding
 	ColWidthDec  key.Binding
+	SortAsc      key.Binding
+	SortDesc     key.Binding
+	SortReset    key.Binding
+	FreezeHeader key.Binding
+	Filter       key.Binding
+	DataProfile  key.Binding
 }
 
 // ShortHelp returns key bindings to be shown in the mini help view
@@ -66,7 +72,9 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.Search, k.NextResult, k.PrevResult, k.ClearSearch},
 		{k.Detail, k.Jump, k.Export, k.Theme},
 		{k.Save, k.SaveAs, k.Visualize, k.SelectRange},
-		{k.ColWidthInc, k.ColWidthDec, k.Help, k.Quit},
+		{k.Filter, k.DataProfile, k.FreezeHeader, k.SortAsc},
+		{k.SortDesc, k.SortReset, k.ColWidthInc, k.ColWidthDec},
+		{k.Help, k.Quit},
 	}
 }
 
@@ -93,7 +101,7 @@ func DefaultKeyMap() KeyMap {
 		ClearSearch:  key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "clear")),
 		Detail:       key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "detail/edit")),
 		Jump:         key.NewBinding(key.WithKeys("ctrl+g"), key.WithHelp("^g", "jump")),
-		ToggleForm:   key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "formulas")),
+		ToggleForm:   key.NewBinding(key.WithKeys("ctrl+f"), key.WithHelp("^f", "formulas")),
 		Copy:         key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy")),
 		CopyRow:      key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "copy row")),
 		Export:       key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export")),
@@ -116,5 +124,11 @@ func DefaultKeyMap() KeyMap {
 		ApplyFormula: key.NewBinding(key.WithKeys("ctrl+a"), key.WithHelp("^a", "apply formula")),
 		ColWidthInc:  key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "widen col")),
 		ColWidthDec:  key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "narrow col")),
+		SortAsc:      key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort asc")),
+		SortDesc:     key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "sort desc")),
+		SortReset:    key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "unsort")),
+		FreezeHeader: key.NewBinding(key.WithKeys("ctrl+r"), key.WithHelp("^r", "freeze header")),
+		Filter:       key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "filter rows")),
+		DataProfile:  key.NewBinding(key.WithKeys("W"), key.WithHelp("W", "data profile")),
 	}
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"strconv"
+
 	"github.com/CodeOne45/vex-tui/internal/theme"
 	"github.com/CodeOne45/vex-tui/internal/ui"
 	"github.com/CodeOne45/vex-tui/pkg/models"
@@ -50,6 +52,34 @@ type Model struct {
 
 	// Pending key for multi-key sequences (dd, dc, gg)
 	pendingKey string
+
+	// Display options
+	freezeHeader bool
+	sortCol      int
+	sortAsc      bool
+	sortActive   bool
+
+	// Sort undo — rows saved before first sort
+	preSortRows    [][]models.Cell
+	preSortMaxRows int
+	preSortSaved   bool
+
+	// Row filter
+	filterInput    textinput.Model
+	filterActive   bool
+	filterQuery    string
+	filterColAll   bool // true = search all cols, false = current col only
+	preFilterRows  [][]models.Cell
+	preFilterMax   int
+}
+
+// colStats holds computed statistics for a numeric column
+type colStats struct {
+	Count int
+	Sum   float64
+	Avg   float64
+	Min   float64
+	Max   float64
 }
 
 // NewModel creates a new application model
@@ -88,6 +118,11 @@ func NewModel(filename string, sheets []models.Sheet, themeName string) Model {
 	saveAsInput.CharLimit = 200
 	saveAsInput.Width = 40
 
+	filterInput := textinput.New()
+	filterInput.Placeholder = "text, >100, <50, =exact  (Tab = all cols)"
+	filterInput.CharLimit = 100
+	filterInput.Width = 50
+
 	fileFormat := "xlsx"
 	if len(filename) > 4 && filename[len(filename)-4:] == ".csv" {
 		fileFormat = "csv"
@@ -101,6 +136,7 @@ func NewModel(filename string, sheets []models.Sheet, themeName string) Model {
 		exportInput:  exportInput,
 		editInput:    editInput,
 		saveAsInput:  saveAsInput,
+		filterInput:  filterInput,
 		help:         help.New(),
 		keys:         DefaultKeyMap(),
 		filename:     filename,
@@ -152,6 +188,40 @@ func (m *Model) centerView() {
 
 	m.offsetRow = ui.Max(0, m.cursorRow-visibleRows/2)
 	m.offsetCol = ui.Max(0, m.cursorCol-visibleCols/2)
+}
+
+// computeColStats returns statistics for the current cursor column, or nil if non-numeric.
+func (m *Model) computeColStats() *colStats {
+	sheet := m.sheets[m.currentSheet]
+	col := m.cursorCol
+
+	var nums []float64
+	startRow := 0
+	if m.freezeHeader && len(sheet.Rows) > 1 {
+		startRow = 1
+	}
+	for i := startRow; i < len(sheet.Rows); i++ {
+		if col < len(sheet.Rows[i]) && sheet.Rows[i][col].Value != "" {
+			if v, err := strconv.ParseFloat(sheet.Rows[i][col].Value, 64); err == nil {
+				nums = append(nums, v)
+			}
+		}
+	}
+	if len(nums) == 0 {
+		return nil
+	}
+
+	sum, mn, mx := nums[0], nums[0], nums[0]
+	for _, v := range nums[1:] {
+		sum += v
+		if v < mn {
+			mn = v
+		}
+		if v > mx {
+			mx = v
+		}
+	}
+	return &colStats{Count: len(nums), Sum: sum, Avg: sum / float64(len(nums)), Min: mn, Max: mx}
 }
 
 // isSearchMatch checks if a cell is a search match

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -65,12 +65,12 @@ type Model struct {
 	preSortSaved   bool
 
 	// Row filter
-	filterInput    textinput.Model
-	filterActive   bool
-	filterQuery    string
-	filterColAll   bool // true = search all cols, false = current col only
-	preFilterRows  [][]models.Cell
-	preFilterMax   int
+	filterInput   textinput.Model
+	filterActive  bool
+	filterQuery   string
+	filterColAll  bool // true = search all cols, false = current col only
+	preFilterRows [][]models.Cell
+	preFilterMax  int
 }
 
 // colStats holds computed statistics for a numeric column

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -804,13 +804,13 @@ func freezeLookup() (string, bool) {
 	// 2. Fixed paths.
 	home, _ := os.UserHomeDir()
 	fixed := []string{
-		"/opt/homebrew/bin/freeze",                      // macOS Apple Silicon (Homebrew symlink)
-		"/opt/homebrew/opt/freeze/bin/freeze",           // macOS Apple Silicon (Homebrew opt)
-		"/usr/local/bin/freeze",                         // macOS Intel (Homebrew symlink) + common Linux
-		"/home/linuxbrew/.linuxbrew/bin/freeze",         // Linuxbrew
-		filepath.Join(home, ".local", "bin", "freeze"),  // Linux non-root installs
-		filepath.Join(home, "go", "bin", "freeze"),      // go install
-		filepath.Join(home, ".brew", "bin", "freeze"),   // custom Homebrew prefix
+		"/opt/homebrew/bin/freeze",                     // macOS Apple Silicon (Homebrew symlink)
+		"/opt/homebrew/opt/freeze/bin/freeze",          // macOS Apple Silicon (Homebrew opt)
+		"/usr/local/bin/freeze",                        // macOS Intel (Homebrew symlink) + common Linux
+		"/home/linuxbrew/.linuxbrew/bin/freeze",        // Linuxbrew
+		filepath.Join(home, ".local", "bin", "freeze"), // Linux non-root installs
+		filepath.Join(home, "go", "bin", "freeze"),     // go install
+		filepath.Join(home, ".brew", "bin", "freeze"),  // custom Homebrew prefix
 	}
 	for _, p := range fixed {
 		if p == "" {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -2,6 +2,10 @@ package app
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -49,6 +53,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateEdit(msg)
 		case models.ModeSaveAs:
 			return m.updateSaveAs(msg)
+		case models.ModeFilter:
+			return m.updateFilter(msg)
+		case models.ModeDataProfile:
+			m.mode = models.ModeNormal
+			return m, nil
 		default:
 			return m.updateNormal(msg)
 		}
@@ -239,6 +248,8 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.isSelecting {
 			m.isSelecting = false
 			m.status = models.StatusMsg{Message: "Selection cancelled", Type: models.StatusInfo}
+		} else if m.filterActive {
+			m.clearFilter()
 		} else if m.searchQuery != "" {
 			m.searchQuery = ""
 			m.searchResults = nil
@@ -367,6 +378,45 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.ApplyFormula):
 		m.quitConfirm = false
 		m.applyFormulaToRange()
+
+	case key.Matches(msg, m.keys.SortAsc):
+		m.quitConfirm = false
+		m.sortByColumn(m.cursorCol, true)
+
+	case key.Matches(msg, m.keys.SortDesc):
+		m.quitConfirm = false
+		m.sortByColumn(m.cursorCol, false)
+
+	case key.Matches(msg, m.keys.SortReset):
+		m.quitConfirm = false
+		m.resetSort()
+
+	case key.Matches(msg, m.keys.Filter):
+		m.quitConfirm = false
+		m.mode = models.ModeFilter
+		m.filterColAll = false
+		m.filterInput.Placeholder = fmt.Sprintf("Filter col %s — text, >100, <50, =val  (Tab=all cols)",
+			ui.ColIndexToLetter(m.cursorCol))
+		m.filterInput.SetValue("")
+		m.filterInput.Focus()
+		return m, textinput.Blink
+
+	case key.Matches(msg, m.keys.DataProfile):
+		m.quitConfirm = false
+		m.mode = models.ModeDataProfile
+		return m, nil
+
+	case key.Matches(msg, m.keys.FreezeHeader):
+		m.quitConfirm = false
+		m.freezeHeader = !m.freezeHeader
+		if m.freezeHeader {
+			if m.cursorRow == 0 && sheet.MaxRows > 1 {
+				m.cursorRow = 1
+			}
+			m.status = models.StatusMsg{Message: "Header frozen — row 1 always visible", Type: models.StatusInfo}
+		} else {
+			m.status = models.StatusMsg{Message: "Header unfrozen", Type: models.StatusInfo}
+		}
 
 	case key.Matches(msg, m.keys.ColWidthInc):
 		m.quitConfirm = false
@@ -734,8 +784,105 @@ func (m Model) updateChart(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.chartType = 2
 	case "4":
 		m.chartType = 3
+	case "p", "P":
+		m.exportChartImage()
 	}
 	return m, nil
+}
+
+// freezeLookup finds the freeze binary across macOS and Linux.
+// Search order:
+//  1. PATH (covers correctly-linked installs everywhere)
+//  2. Fixed well-known paths (Homebrew symlinks, Linuxbrew, user-local)
+//  3. Homebrew / Linuxbrew Cellar walk (catches broken symlinks)
+func freezeLookup() (string, bool) {
+	// 1. Respect PATH first — works for any correctly installed binary.
+	if p, err := exec.LookPath("freeze"); err == nil {
+		return p, true
+	}
+
+	// 2. Fixed paths.
+	home, _ := os.UserHomeDir()
+	fixed := []string{
+		"/opt/homebrew/bin/freeze",                      // macOS Apple Silicon (Homebrew symlink)
+		"/opt/homebrew/opt/freeze/bin/freeze",           // macOS Apple Silicon (Homebrew opt)
+		"/usr/local/bin/freeze",                         // macOS Intel (Homebrew symlink) + common Linux
+		"/home/linuxbrew/.linuxbrew/bin/freeze",         // Linuxbrew
+		filepath.Join(home, ".local", "bin", "freeze"),  // Linux non-root installs
+		filepath.Join(home, "go", "bin", "freeze"),      // go install
+		filepath.Join(home, ".brew", "bin", "freeze"),   // custom Homebrew prefix
+	}
+	for _, p := range fixed {
+		if p == "" {
+			continue
+		}
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p, true
+		}
+	}
+
+	// 3. Cellar walk — catches Homebrew installs whose bin symlink is missing.
+	cellarRoots := []string{
+		"/opt/homebrew/Cellar/freeze",              // Apple Silicon
+		"/usr/local/Cellar/freeze",                 // Intel macOS
+		"/home/linuxbrew/.linuxbrew/Cellar/freeze", // Linuxbrew
+	}
+	for _, root := range cellarRoots {
+		versions, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, v := range versions {
+			p := filepath.Join(root, v.Name(), "bin", "freeze")
+			if info, err := os.Stat(p); err == nil && !info.IsDir() {
+				return p, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// exportChartImage renders the current chart and saves it as a PNG via the
+// `freeze` CLI (github.com/charmbracelet/freeze). Falls back to a clear
+// install hint if freeze is not found.
+func (m *Model) exportChartImage() {
+	freezePath, found := freezeLookup()
+	if !found {
+		m.status = models.StatusMsg{
+			Message: "freeze not found — install: brew install charmbracelet/tap/freeze",
+			Type:    models.StatusWarning,
+		}
+		return
+	}
+
+	// Build the output filename next to the source file.
+	base := strings.TrimSuffix(filepath.Base(m.filename), filepath.Ext(m.filename))
+	outFile := base + "-chart.png"
+
+	// Render the chart modal (returns an ANSI string from lipgloss).
+	chartANSI := m.renderChart()
+
+	cmd := exec.Command(freezePath,
+		"--output", outFile,
+		"--padding", "20,30",
+		"--border.radius", "8",
+		"--shadow",
+	)
+	cmd.Stdin = strings.NewReader(chartANSI)
+
+	if err := cmd.Run(); err != nil {
+		m.status = models.StatusMsg{
+			Message: fmt.Sprintf("Export failed: %v", err),
+			Type:    models.StatusError,
+		}
+		return
+	}
+
+	m.status = models.StatusMsg{
+		Message: fmt.Sprintf("✓ Saved %s", outFile),
+		Type:    models.StatusSuccess,
+	}
 }
 
 // updateSelectRange handles range selection mode
@@ -787,4 +934,230 @@ func abs(x int) int {
 		return -x
 	}
 	return x
+}
+
+// resetSort restores the pre-sort row order.
+func (m *Model) resetSort() {
+	if !m.preSortSaved {
+		m.status = models.StatusMsg{Message: "No sort to undo", Type: models.StatusInfo}
+		return
+	}
+	sheet := &m.sheets[m.currentSheet]
+	sheet.Rows = m.preSortRows
+	sheet.MaxRows = m.preSortMaxRows
+	m.preSortSaved = false
+	m.preSortRows = nil
+	m.sortActive = false
+	m.cursorRow = 0
+	m.offsetRow = 0
+	m.status = models.StatusMsg{Message: "Sort cleared — original order restored", Type: models.StatusInfo}
+}
+
+// updateFilter handles the filter input mode.
+func (m Model) updateFilter(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg.Type {
+	case tea.KeyEscape:
+		m.mode = models.ModeNormal
+		m.filterInput.Blur()
+		return m, nil
+
+	case tea.KeyTab:
+		m.filterColAll = !m.filterColAll
+		if m.filterColAll {
+			m.filterInput.Placeholder = "Filter ALL columns — text, >100, <50, =val"
+		} else {
+			m.filterInput.Placeholder = fmt.Sprintf("Filter col %s — text, >100, <50, =val  (Tab=all cols)",
+				ui.ColIndexToLetter(m.cursorCol))
+		}
+		return m, nil
+
+	case tea.KeyEnter:
+		expr := strings.TrimSpace(m.filterInput.Value())
+		m.filterInput.Blur()
+		m.mode = models.ModeNormal
+		if expr == "" {
+			m.clearFilter()
+		} else {
+			m.applyFilter(expr)
+		}
+		return m, nil
+	}
+
+	m.filterInput, cmd = m.filterInput.Update(msg)
+	return m, cmd
+}
+
+// applyFilter filters the current sheet rows by the given expression.
+// Expression formats: plain text (contains), >N, <N, >=N, <=N, =exact.
+func (m *Model) applyFilter(expr string) {
+	sheet := &m.sheets[m.currentSheet]
+
+	// Save original rows if not already filtered
+	if !m.filterActive {
+		rows := make([][]models.Cell, len(sheet.Rows))
+		copy(rows, sheet.Rows)
+		m.preFilterRows = rows
+		m.preFilterMax = sheet.MaxRows
+	}
+
+	col := m.cursorCol
+	matchRow := func(row []models.Cell) bool {
+		if m.filterColAll {
+			for _, cell := range row {
+				if matchExpr(cell.Value, expr) {
+					return true
+				}
+			}
+			return false
+		}
+		if col < len(row) {
+			return matchExpr(row[col].Value, expr)
+		}
+		return false
+	}
+
+	var filtered [][]models.Cell
+	for _, row := range m.preFilterRows {
+		if matchRow(row) {
+			filtered = append(filtered, row)
+		}
+	}
+
+	if len(filtered) == 0 {
+		m.status = models.StatusMsg{Message: "No rows match — filter not applied", Type: models.StatusWarning}
+		return
+	}
+
+	sheet.Rows = filtered
+	sheet.MaxRows = len(filtered)
+	m.filterActive = true
+	m.filterQuery = expr
+	m.cursorRow = 0
+	m.offsetRow = 0
+
+	scope := fmt.Sprintf("col %s", ui.ColIndexToLetter(col))
+	if m.filterColAll {
+		scope = "all cols"
+	}
+	m.status = models.StatusMsg{
+		Message: fmt.Sprintf("Filter [%s] on %s — %d/%d rows  (Esc or f + Enter to clear)",
+			expr, scope, len(filtered), m.preFilterMax),
+		Type: models.StatusSuccess,
+	}
+}
+
+// clearFilter restores the pre-filter rows.
+func (m *Model) clearFilter() {
+	if !m.filterActive {
+		return
+	}
+	sheet := &m.sheets[m.currentSheet]
+	sheet.Rows = m.preFilterRows
+	sheet.MaxRows = m.preFilterMax
+	m.filterActive = false
+	m.filterQuery = ""
+	m.preFilterRows = nil
+	m.cursorRow = 0
+	m.offsetRow = 0
+	m.status = models.StatusMsg{Message: "Filter cleared", Type: models.StatusInfo}
+}
+
+// matchExpr tests whether a cell value satisfies the filter expression.
+func matchExpr(value, expr string) bool {
+	// Numeric comparisons
+	for _, prefix := range []string{">=", "<=", ">", "<", "="} {
+		if strings.HasPrefix(expr, prefix) {
+			operand := strings.TrimSpace(expr[len(prefix):])
+			target, err1 := strconv.ParseFloat(operand, 64)
+			actual, err2 := strconv.ParseFloat(value, 64)
+			if err1 != nil || err2 != nil {
+				if prefix == "=" {
+					return strings.EqualFold(value, operand)
+				}
+				return false
+			}
+			switch prefix {
+			case ">=":
+				return actual >= target
+			case "<=":
+				return actual <= target
+			case ">":
+				return actual > target
+			case "<":
+				return actual < target
+			case "=":
+				return actual == target
+			}
+		}
+	}
+	// Default: case-insensitive contains
+	return strings.Contains(strings.ToLower(value), strings.ToLower(expr))
+}
+
+// sortByColumn sorts the sheet rows by the given column. If freezeHeader is
+// enabled the first row is treated as a header and kept in place.
+func (m *Model) sortByColumn(col int, ascending bool) {
+	sheet := &m.sheets[m.currentSheet]
+	if len(sheet.Rows) == 0 {
+		return
+	}
+
+	// Save original order before first sort
+	if !m.preSortSaved {
+		saved := make([][]models.Cell, len(sheet.Rows))
+		copy(saved, sheet.Rows)
+		m.preSortRows = saved
+		m.preSortMaxRows = sheet.MaxRows
+		m.preSortSaved = true
+	}
+
+	startRow := 0
+	if m.freezeHeader && len(sheet.Rows) > 1 {
+		startRow = 1
+	}
+
+	data := sheet.Rows[startRow:]
+	sort.SliceStable(data, func(i, j int) bool {
+		vi, vj := "", ""
+		if col < len(data[i]) {
+			vi = data[i][col].Value
+		}
+		if col < len(data[j]) {
+			vj = data[j][col].Value
+		}
+		ni, erri := strconv.ParseFloat(vi, 64)
+		nj, errj := strconv.ParseFloat(vj, 64)
+		if erri == nil && errj == nil {
+			if ascending {
+				return ni < nj
+			}
+			return ni > nj
+		}
+		if ascending {
+			return strings.ToLower(vi) < strings.ToLower(vj)
+		}
+		return strings.ToLower(vi) > strings.ToLower(vj)
+	})
+
+	// Fix row indices after sort
+	for i := range sheet.Rows {
+		for j := range sheet.Rows[i] {
+			sheet.Rows[i][j].Row = i
+		}
+	}
+
+	m.modified = true
+	m.sortCol = col
+	m.sortAsc = ascending
+	m.sortActive = true
+	dir := "↑"
+	if !ascending {
+		dir = "↓"
+	}
+	m.status = models.StatusMsg{
+		Message: fmt.Sprintf("Sorted by %s %s", ui.ColIndexToLetter(col), dir),
+		Type:    models.StatusSuccess,
+	}
 }

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -38,6 +38,10 @@ func (m Model) View() string {
 		return m.renderEditMode()
 	case models.ModeSaveAs:
 		return ui.RenderModal(m.width, m.height, m.renderSaveAs())
+	case models.ModeFilter:
+		return m.renderFilterMode()
+	case models.ModeDataProfile:
+		return ui.RenderModal(m.width, m.height, m.renderDataProfile())
 	default:
 		return m.renderNormal()
 	}
@@ -61,14 +65,33 @@ func (m Model) renderNormal() string {
 	sheet := m.sheets[m.currentSheet]
 	var b strings.Builder
 
-	// Title bar
-	title := fmt.Sprintf("📊 %s", m.filename)
-	if len(m.sheets) > 1 {
-		title += fmt.Sprintf(" • %s (%d/%d)", sheet.Name, m.currentSheet+1, len(m.sheets))
-	} else {
-		title += fmt.Sprintf(" • %s", sheet.Name)
+	// Title bar — show modified indicator and freeze/sort state
+	modMark := ""
+	if m.modified {
+		modMark = lipgloss.NewStyle().Foreground(theme.GetCurrentTheme().Warning).Bold(true).Render(" ●")
 	}
-	b.WriteString(m.styles.Title.Render(title))
+	sheetInfo := sheet.Name
+	if len(m.sheets) > 1 {
+		sheetInfo = fmt.Sprintf("%s (%d/%d)", sheet.Name, m.currentSheet+1, len(m.sheets))
+	}
+	extras := ""
+	if m.freezeHeader {
+		extras += lipgloss.NewStyle().Foreground(theme.GetCurrentTheme().Accent).Render(" ⌶")
+	}
+	if m.filterActive {
+		extras += lipgloss.NewStyle().Foreground(theme.GetCurrentTheme().Warning).
+			Render(fmt.Sprintf(" ▾ %s", m.filterQuery))
+	}
+	if m.sortActive {
+		dir := "↑"
+		if !m.sortAsc {
+			dir = "↓"
+		}
+		extras += lipgloss.NewStyle().Foreground(theme.GetCurrentTheme().Secondary).
+			Render(fmt.Sprintf(" %s%s", ui.ColIndexToLetter(m.sortCol), dir))
+	}
+	title := fmt.Sprintf("  %s  •  %s%s", m.filename, sheetInfo, extras)
+	b.WriteString(m.styles.Title.Render(title) + modMark)
 	b.WriteString("\n")
 
 	// Formula bar
@@ -123,7 +146,6 @@ func (m Model) renderFormulaBar() string {
 }
 
 // renderTable renders the spreadsheet table
-// renderTable renders the spreadsheet table
 func (m Model) renderTable() string {
 	sheet := m.sheets[m.currentSheet]
 	visibleRows := ui.Max(1, m.height-9)
@@ -131,93 +153,117 @@ func (m Model) renderTable() string {
 
 	var b strings.Builder
 	sep := m.styles.Separator.Render("│")
+	t := theme.GetCurrentTheme()
 
-	// Column headers
-	b.WriteString(m.styles.RowNum.Render(""))
-	b.WriteString(sep)
-
-	for col := m.offsetCol; col < ui.Min(m.offsetCol+visibleCols, sheet.MaxCols); col++ {
-		width := ui.MinCellWidth
-		if w, ok := sheet.ColWidths[col]; ok && w > 0 {
-			width = w
-		}
-
-		colLetter := ui.ColIndexToLetter(col)
-		headerStyle := m.styles.Header
-		if col == m.cursorCol {
-			headerStyle = m.styles.HeaderHighlight
-		}
-
-		// Adjust style width
-		headerStyle = headerStyle.Width(width)
-		b.WriteString(headerStyle.Render(ui.PadCenter(colLetter, width)))
+	renderColHeaders := func() {
+		b.WriteString(m.styles.RowNum.Render(""))
 		b.WriteString(sep)
+		for col := m.offsetCol; col < ui.Min(m.offsetCol+visibleCols, sheet.MaxCols); col++ {
+			width := ui.MinCellWidth
+			if w, ok := sheet.ColWidths[col]; ok && w > 0 {
+				width = w
+			}
+			label := ui.ColIndexToLetter(col)
+			if m.sortActive && col == m.sortCol {
+				if m.sortAsc {
+					label += "↑"
+				} else {
+					label += "↓"
+				}
+			}
+			headerStyle := m.styles.Header
+			if col == m.cursorCol {
+				headerStyle = m.styles.HeaderHighlight
+			}
+			b.WriteString(headerStyle.Width(width).Render(ui.PadCenter(label, width)))
+			b.WriteString(sep)
+		}
+		b.WriteString("\n")
 	}
-	b.WriteString("\n")
 
-	// Data rows
-	endRow := ui.Min(m.offsetRow+visibleRows, sheet.MaxRows)
-	for row := m.offsetRow; row < endRow; row++ {
-		// Row number
+	renderRow := func(row int, isHeaderPin bool) {
 		if row == m.cursorRow {
 			b.WriteString(m.styles.SelectedRowNum.Render(fmt.Sprintf("%d", row+1)))
+		} else if isHeaderPin {
+			b.WriteString(lipgloss.NewStyle().
+				Foreground(t.Primary).Bold(true).Align(lipgloss.Right).Width(5).
+				Render(fmt.Sprintf("%d", row+1)))
 		} else {
 			b.WriteString(m.styles.RowNum.Render(fmt.Sprintf("%d", row+1)))
 		}
 		b.WriteString(sep)
 
-		// Cells
 		if row < len(sheet.Rows) {
 			for col := m.offsetCol; col < ui.Min(m.offsetCol+visibleCols, sheet.MaxCols); col++ {
-				cellText := ""
 				width := ui.MinCellWidth
 				if w, ok := sheet.ColWidths[col]; ok && w > 0 {
 					width = w
 				}
 
+				rawVal := ""
+				isFormula := false
+				isEmpty := true
 				if col < len(sheet.Rows[row]) {
 					cell := sheet.Rows[row][col]
+					isEmpty = cell.Value == "" && cell.Formula == ""
 					if m.showFormulas && cell.Formula != "" {
-						cellText = "=" + cell.Formula
+						rawVal = "=" + cell.Formula
+						isFormula = true
 					} else {
-						cellText = cell.Value
+						rawVal = cell.Value
+						isFormula = cell.Formula != ""
 					}
 				}
 
-				cellText = ui.TruncateToWidth(cellText, width)
+				cellText := ui.TruncateToWidth(rawVal, width)
 
-				// Determine style
 				var style lipgloss.Style
-				if row == m.cursorRow && col == m.cursorCol {
+				switch {
+				case row == m.cursorRow && col == m.cursorCol:
 					style = m.styles.SelectedCell
-				} else if m.isSelecting && m.isInSelection(row, col) {
-					// Highlight selection with different color
-					style = lipgloss.NewStyle().
-						Foreground(theme.GetCurrentTheme().Text).
-						Background(theme.GetCurrentTheme().Secondary)
-
-				} else if m.isSearchMatch(row, col) {
+				case m.isSelecting && m.isInSelection(row, col):
+					style = m.styles.SelectionCell
+				case m.isSearchMatch(row, col):
 					style = m.styles.SearchMatch
-				} else if row == m.cursorRow {
+				case isHeaderPin:
+					style = m.styles.FrozenHeaderCell
+				case row == m.cursorRow:
 					style = m.styles.RowHighlight
-				} else if col == m.cursorCol {
-					style = m.styles.ColHighlight
-				} else {
-					style = m.styles.Cell
+				case col == m.cursorCol:
+					// apply cell-type coloring within col highlight
+					if isFormula {
+						style = m.styles.ColHighlight.Foreground(t.Secondary)
+					} else if !isEmpty {
+						if _, err := strconv.ParseFloat(rawVal, 64); err == nil {
+							style = m.styles.ColHighlight.Foreground(t.Accent)
+						} else {
+							style = m.styles.ColHighlight
+						}
+					} else {
+						style = m.styles.ColHighlight
+					}
+				default:
+					// Cell type coloring in normal cells
+					if isFormula {
+						style = m.styles.FormulaCell
+					} else if isEmpty {
+						style = m.styles.Cell
+					} else if _, err := strconv.ParseFloat(rawVal, 64); err == nil {
+						style = m.styles.NumberCell
+					} else {
+						style = m.styles.Cell
+					}
 				}
 
-				style = style.Width(width)
-				b.WriteString(style.Render(cellText))
+				b.WriteString(style.Width(width).Render(cellText))
 				b.WriteString(sep)
 			}
 		} else {
-			// Empty row
 			for col := m.offsetCol; col < ui.Min(m.offsetCol+visibleCols, sheet.MaxCols); col++ {
 				width := ui.MinCellWidth
 				if w, ok := sheet.ColWidths[col]; ok && w > 0 {
 					width = w
 				}
-
 				var style lipgloss.Style
 				if row == m.cursorRow && col == m.cursorCol {
 					style = m.styles.SelectedCell
@@ -228,12 +274,36 @@ func (m Model) renderTable() string {
 				} else {
 					style = m.styles.Cell
 				}
-				style = style.Width(width)
-				b.WriteString(style.Render(strings.Repeat(" ", width)))
+				b.WriteString(style.Width(width).Render(strings.Repeat(" ", width)))
 				b.WriteString(sep)
 			}
 		}
 		b.WriteString("\n")
+	}
+
+	renderColHeaders()
+
+	// Frozen header row — always pinned at top
+	if m.freezeHeader && sheet.MaxRows > 0 {
+		renderRow(0, true)
+		b.WriteString(m.styles.FrozenDivider.Render(strings.Repeat("─", m.width-2)) + "\n")
+	}
+
+	// Determine scrollable viewport start row
+	startRow := m.offsetRow
+	if m.freezeHeader && startRow == 0 && sheet.MaxRows > 1 {
+		startRow = 1
+	}
+
+	endRow := ui.Min(startRow+visibleRows, sheet.MaxRows)
+	if m.freezeHeader {
+		endRow = ui.Min(startRow+visibleRows-2, sheet.MaxRows)
+	}
+	for row := startRow; row < endRow; row++ {
+		if m.freezeHeader && row == 0 {
+			continue
+		}
+		renderRow(row, false)
 	}
 
 	return b.String()
@@ -244,34 +314,73 @@ func (m Model) renderStatusBar() string {
 	sheet := m.sheets[m.currentSheet]
 	t := theme.GetCurrentTheme()
 
-	parts := []string{
-		lipgloss.NewStyle().Foreground(t.Secondary).Bold(true).Render("Rows:") +
-			lipgloss.NewStyle().Foreground(t.Text).Render(fmt.Sprintf(" %d", sheet.MaxRows)),
-		lipgloss.NewStyle().Foreground(t.Secondary).Bold(true).Render("Cols:") +
-			lipgloss.NewStyle().Foreground(t.Text).Render(fmt.Sprintf(" %d", sheet.MaxCols)),
-		lipgloss.NewStyle().Foreground(t.Secondary).Bold(true).Render("Pos:") +
-			lipgloss.NewStyle().Foreground(t.Text).Render(fmt.Sprintf(" %s", ui.ColIndexToLetter(m.cursorCol)+fmt.Sprintf("%d", m.cursorRow+1))),
-	}
+	dim := lipgloss.NewStyle().Foreground(t.DimText)
+	bold := lipgloss.NewStyle().Foreground(t.Secondary).Bold(true)
+	accent := lipgloss.NewStyle().Foreground(t.Accent)
 
+	cellRef := ui.ColIndexToLetter(m.cursorCol) + fmt.Sprintf("%d", m.cursorRow+1)
+
+	// Left cluster: position + dimensions
+	left := []string{
+		bold.Render(cellRef),
+		dim.Render(fmt.Sprintf("%d×%d", sheet.MaxRows, sheet.MaxCols)),
+	}
 	if m.showFormulas {
-		parts = append(parts, lipgloss.NewStyle().Foreground(t.Accent).Render("Formulas"))
+		left = append(left, accent.Render("ƒx"))
+	}
+	if m.freezeHeader {
+		left = append(left, accent.Render("⌶"))
 	}
 
+	// Middle cluster: selection info or column stats
+	middle := []string{}
+	if m.isSelecting {
+		rows := abs(m.selectEnd[0]-m.selectStart[0]) + 1
+		cols := abs(m.selectEnd[1]-m.selectStart[1]) + 1
+		middle = append(middle, lipgloss.NewStyle().Foreground(t.Primary).Bold(true).
+			Render(fmt.Sprintf("▋ %d×%d", rows, cols)))
+	} else if stats := m.computeColStats(); stats != nil {
+		middle = append(middle,
+			dim.Render("Σ ")+accent.Render(formatStatNum(stats.Sum)),
+			dim.Render("avg ")+accent.Render(formatStatNum(stats.Avg)),
+			dim.Render("min ")+accent.Render(formatStatNum(stats.Min)),
+			dim.Render("max ")+accent.Render(formatStatNum(stats.Max)),
+			dim.Render(fmt.Sprintf("n=%d", stats.Count)),
+		)
+	}
+
+	// Right cluster: search + status message
+	right := []string{}
 	if len(m.searchResults) > 0 {
-		parts = append(parts, lipgloss.NewStyle().
-			Foreground(t.SearchMatch).
-			Bold(true).
-			Render(fmt.Sprintf("🔍 %d/%d", m.searchIndex+1, len(m.searchResults))))
+		right = append(right, lipgloss.NewStyle().Foreground(t.SearchMatch).Bold(true).
+			Render(fmt.Sprintf("/%s  %d/%d", m.searchQuery, m.searchIndex+1, len(m.searchResults))))
 	}
-
 	if m.status.Message != "" {
-		statusColor := ui.GetStatusColor(m.status.Type)
-		parts = append(parts, lipgloss.NewStyle().
-			Foreground(statusColor).
+		right = append(right, lipgloss.NewStyle().Foreground(ui.GetStatusColor(m.status.Type)).
 			Render(m.status.Message))
 	}
 
-	return m.styles.StatusBar.Render(strings.Join(parts, " │ "))
+	sep := dim.Render("  │  ")
+	var allParts []string
+	if len(left) > 0 {
+		allParts = append(allParts, strings.Join(left, "  "))
+	}
+	if len(middle) > 0 {
+		allParts = append(allParts, strings.Join(middle, "  "))
+	}
+	if len(right) > 0 {
+		allParts = append(allParts, strings.Join(right, "  "))
+	}
+
+	return m.styles.StatusBar.Render(strings.Join(allParts, sep))
+}
+
+// formatStatNum formats a float for compact status bar display.
+func formatStatNum(v float64) string {
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d", int64(v))
+	}
+	return fmt.Sprintf("%.2f", v)
 }
 
 // renderSearchBar renders the search bar
@@ -395,66 +504,84 @@ func (m Model) renderThemeSelector() string {
 		Italic(true).
 		Render("\nPress 1-9, 0 to select, Esc to cancel")
 
-	return m.styles.Modal.Width(60).Render(content)
+	modalW := ui.Max(50, ui.Min(m.width-4, 64))
+	return m.styles.Modal.Width(modalW).Render(content)
 }
 
 // renderChart renders the chart visualization modal
 func (m Model) renderChart() string {
 	t := theme.GetCurrentTheme()
 
-	content := m.styles.ModalTitle.Render("📊 Data Visualization") + "\n\n"
+	modalW := ui.Max(60, ui.Min(m.width-4, 90))
+	modalH := ui.Max(20, ui.Min(m.height-4, 36))
+	barW := modalW - 26 // label(16) + " │ "(3) + value(7)
+	if barW < 10 {
+		barW = 10
+	}
+	chartH := modalH - 12 // reserve for type tabs + footer
+	if chartH < 6 {
+		chartH = 6
+	}
 
-	// Show chart type selector
-	types := []string{"1. Bar Chart", "2. Line Chart", "3. Sparkline", "4. Pie Chart"}
+	// Chart type tabs
+	types := []struct{ num, name string }{
+		{"1", "Bar"}, {"2", "Line"}, {"3", "Sparkline"}, {"4", "Pie"},
+	}
+	var tabs strings.Builder
 	for i, typ := range types {
 		if i == m.chartType {
-			content += lipgloss.NewStyle().Foreground(t.Accent).Bold(true).Render("→ "+typ) + "\n"
+			tabs.WriteString(lipgloss.NewStyle().
+				Background(t.Accent).Foreground(lipgloss.Color("#000000")).
+				Bold(true).Padding(0, 1).
+				Render(typ.num+". "+typ.name) + " ")
 		} else {
-			content += lipgloss.NewStyle().Foreground(t.Text).Render("  "+typ) + "\n"
+			tabs.WriteString(lipgloss.NewStyle().
+				Foreground(t.DimText).Padding(0, 1).
+				Render(typ.num+". "+typ.name) + " ")
 		}
 	}
 
-	content += "\n" + strings.Repeat("─", 60) + "\n\n"
-
-	// Extract data from selection
-	startRow := m.selectStart[0]
-	startCol := m.selectStart[1]
-	endRow := m.selectEnd[0]
-	endCol := m.selectEnd[1]
-
-	// Normalize selection
+	// Extract data
+	startRow, startCol := m.selectStart[0], m.selectStart[1]
+	endRow, endCol := m.selectEnd[0], m.selectEnd[1]
 	if startRow > endRow {
 		startRow, endRow = endRow, startRow
 	}
 	if startCol > endCol {
 		startCol, endCol = endCol, startCol
 	}
+	cd := extractChartData(m.sheets[m.currentSheet], startRow, startCol, endRow, endCol)
 
-	// Import chart package
-	chartData := extractChartData(m.sheets[m.currentSheet], startRow, startCol, endRow, endCol)
+	divider := lipgloss.NewStyle().Foreground(t.Border).Render(strings.Repeat("─", modalW-4))
 
-	// Render chart
-	modalStyle := lipgloss.NewStyle()
-
+	var chartContent string
+	colors := []lipgloss.Color{t.Accent, t.Primary, t.Secondary, t.Success, t.Warning}
 	switch m.chartType {
-	case 0: // Bar
-		content += renderBarChart(chartData, modalStyle, t.Accent, t.Text)
-	case 1: // Line
-		content += renderLineChart(chartData, modalStyle, t.Accent, t.Text)
-	case 2: // Sparkline
-		content += "Sparkline: " + renderSparkline(chartData, t.Accent) + "\n"
-		content += renderBarChart(chartData, modalStyle, t.Accent, t.Text)
-	case 3: // Pie
-		colors := []lipgloss.Color{t.Accent, t.Primary, t.Secondary, t.Success, t.Warning}
-		content += renderPieChart(chartData, modalStyle, colors, t.Text)
+	case 0:
+		chartContent = renderBarChart(cd, barW, t.Accent, t.Text)
+	case 1:
+		chartContent = renderLineChart(cd, barW, chartH, t.Accent, t.Text)
+	case 2:
+		chartContent = "  " + renderSparkline(cd, t.Accent) + "\n\n" +
+			renderBarChart(cd, barW, t.Accent, t.Text)
+	case 3:
+		chartContent = renderPieChart(cd, colors, t.Text)
 	}
 
-	content += "\n" + lipgloss.NewStyle().
-		Foreground(t.DimText).
-		Italic(true).
-		Render("Press 1-4 to switch chart type, Esc to close")
+	if len(cd.Values) == 0 {
+		chartContent = lipgloss.NewStyle().Foreground(t.DimText).
+			Render("  No numeric data in selection.\n  Select a range with a label column + value column.")
+	}
 
-	return m.styles.Modal.Width(70).Height(30).Render(content)
+	content := m.styles.ModalTitle.Render("  Data Visualization") + "\n\n" +
+		tabs.String() + "\n\n" +
+		divider + "\n\n" +
+		chartContent + "\n\n" +
+		divider + "\n" +
+		lipgloss.NewStyle().Foreground(t.DimText).Italic(true).
+			Render("  1-4 switch type  •  p export as image  •  Esc close")
+
+	return m.styles.Modal.Width(modalW).Height(modalH).Render(content)
 }
 
 // renderSelectRange renders the selection mode overlay
@@ -497,32 +624,212 @@ func (m Model) isInSelection(row, col int) bool {
 	return row >= startRow && row <= endRow && col >= startCol && col <= endCol
 }
 
-// Chart rendering helpers using internal/chart package
+// renderFilterMode renders the normal view with a filter input bar at the bottom.
+func (m Model) renderFilterMode() string {
+	base := m.renderNormal()
+	t := theme.GetCurrentTheme()
+
+	scope := fmt.Sprintf("col %s", ui.ColIndexToLetter(m.cursorCol))
+	if m.filterColAll {
+		scope = "all cols"
+	}
+	label := lipgloss.NewStyle().
+		Background(t.Warning).Foreground(lipgloss.Color("#000000")).
+		Bold(true).Padding(0, 1).
+		Render(fmt.Sprintf("FILTER [%s]", scope))
+	hint := lipgloss.NewStyle().Foreground(t.DimText).
+		Render("  Tab=toggle scope  Enter=apply  Esc=cancel")
+	bar := lipgloss.NewStyle().Background(t.Border).Padding(0, 1).
+		Render(label + "  " + m.filterInput.View() + hint)
+
+	return base + "\n" + bar
+}
+
+// renderDataProfile renders a per-column statistical summary.
+func (m Model) renderDataProfile() string {
+	sheet := m.sheets[m.currentSheet]
+	t := theme.GetCurrentTheme()
+
+	modalW := ui.Max(70, ui.Min(m.width-4, 90))
+
+	title := m.styles.ModalTitle.Render("  Data Profile")
+	summary := lipgloss.NewStyle().Foreground(t.DimText).
+		Render(fmt.Sprintf("  %d rows  •  %d columns  •  %s",
+			sheet.MaxRows, sheet.MaxCols, m.filename))
+
+	header := lipgloss.NewStyle().Foreground(t.Secondary).Bold(true).
+		Render(fmt.Sprintf("\n  %-4s %-16s %-8s %-8s %-8s %s\n",
+			"Col", "Type", "Non-null", "Nulls", "Unique", "Stats"))
+	divider := lipgloss.NewStyle().Foreground(t.Border).
+		Render("  " + strings.Repeat("─", modalW-6) + "\n")
+
+	var rows strings.Builder
+	for col := 0; col < sheet.MaxCols; col++ {
+		colLetter := ui.ColIndexToLetter(col)
+
+		var vals []string
+		nullCount := 0
+		for _, row := range sheet.Rows {
+			if col < len(row) {
+				v := row[col].Value
+				if v == "" {
+					nullCount++
+				} else {
+					vals = append(vals, v)
+				}
+			} else {
+				nullCount++
+			}
+		}
+
+		nonNull := len(vals)
+
+		// Detect type
+		numericCount := 0
+		var nums []float64
+		for _, v := range vals {
+			if n, err := strconv.ParseFloat(v, 64); err == nil {
+				numericCount++
+				nums = append(nums, n)
+			}
+		}
+
+		colType := "text"
+		typeColor := t.Text
+		statsStr := ""
+
+		if numericCount == nonNull && nonNull > 0 {
+			colType = "number"
+			typeColor = t.Accent
+			sum, mn, mx := nums[0], nums[0], nums[0]
+			for _, n := range nums[1:] {
+				sum += n
+				if n < mn {
+					mn = n
+				}
+				if n > mx {
+					mx = n
+				}
+			}
+			avg := sum / float64(len(nums))
+			statsStr = fmt.Sprintf("Σ%-8s avg %-8s [%s – %s]",
+				formatStatNum(sum), formatStatNum(avg),
+				formatStatNum(mn), formatStatNum(mx))
+		} else {
+			// Unique count + sample values
+			seen := make(map[string]struct{})
+			for _, v := range vals {
+				seen[v] = struct{}{}
+			}
+			unique := len(seen)
+			sample := ""
+			count := 0
+			for v := range seen {
+				if count >= 3 {
+					break
+				}
+				if sample != "" {
+					sample += ", "
+				}
+				if len(v) > 10 {
+					v = v[:9] + "…"
+				}
+				sample += v
+				count++
+			}
+			if unique > 3 {
+				sample += "…"
+			}
+			statsStr = fmt.Sprintf("%d unique  %s", unique, sample)
+			if numericCount > 0 && numericCount < nonNull {
+				colType = "mixed"
+				typeColor = t.Warning
+			}
+		}
+
+		highlight := col == m.cursorCol
+		rowStyle := lipgloss.NewStyle().Foreground(t.Text)
+		if highlight {
+			rowStyle = rowStyle.Background(t.RowHighlight)
+		}
+
+		line := fmt.Sprintf("  %-4s %-16s %-8d %-8d %-8s %s",
+			colLetter,
+			lipgloss.NewStyle().Foreground(typeColor).Render(colType),
+			nonNull,
+			nullCount,
+			"",
+			statsStr,
+		)
+		rows.WriteString(rowStyle.Render(line) + "\n")
+	}
+
+	content := title + "\n" + summary + "\n" + header + divider + rows.String() + "\n" +
+		lipgloss.NewStyle().Foreground(t.DimText).Italic(true).
+			Render("  Any key to close  •  highlighted column = cursor position")
+
+	return m.styles.Modal.Width(modalW).Render(content)
+}
+
+// extractChartData extracts chart data from a selection.
+// If the first column of the selection is non-numeric it becomes labels;
+// otherwise row numbers are used as labels. The first numeric column is used
+// as values.
 func extractChartData(sheet models.Sheet, startRow, startCol, endRow, endCol int) chartData {
 	data := chartData{
 		Labels: make([]string, 0),
 		Values: make([]float64, 0),
 	}
+	if startRow > endRow || startCol > endCol {
+		return data
+	}
 
+	// Determine whether the first selected column is a label column (non-numeric)
+	firstColNumeric := true
 	for row := startRow; row <= endRow && row < len(sheet.Rows); row++ {
 		if startCol < len(sheet.Rows[row]) {
-			label := sheet.Rows[row][startCol].Value
-			if label == "" {
-				label = fmt.Sprintf("Row %d", row+1)
-			}
-			data.Labels = append(data.Labels, label)
-
-			if startCol+1 <= endCol && startCol+1 < len(sheet.Rows[row]) {
-				valStr := sheet.Rows[row][startCol+1].Value
-				if val, err := strconv.ParseFloat(valStr, 64); err == nil {
-					data.Values = append(data.Values, val)
-				} else {
-					data.Values = append(data.Values, 0)
+			if _, err := strconv.ParseFloat(sheet.Rows[row][startCol].Value, 64); err != nil {
+				if sheet.Rows[row][startCol].Value != "" {
+					firstColNumeric = false
+					break
 				}
 			}
 		}
 	}
 
+	labelCol := -1
+	valueCol := startCol
+	if !firstColNumeric {
+		labelCol = startCol
+		// Find first numeric col after label col
+		for col := startCol + 1; col <= endCol; col++ {
+			for row := startRow; row <= endRow && row < len(sheet.Rows); row++ {
+				if col < len(sheet.Rows[row]) {
+					if _, err := strconv.ParseFloat(sheet.Rows[row][col].Value, 64); err == nil {
+						valueCol = col
+						goto foundValueCol
+					}
+				}
+			}
+		}
+	}
+foundValueCol:
+
+	for row := startRow; row <= endRow && row < len(sheet.Rows); row++ {
+		label := fmt.Sprintf("%d", row+1)
+		if labelCol >= 0 && labelCol < len(sheet.Rows[row]) {
+			if v := sheet.Rows[row][labelCol].Value; v != "" {
+				label = v
+			}
+		}
+
+		if valueCol < len(sheet.Rows[row]) {
+			if val, err := strconv.ParseFloat(sheet.Rows[row][valueCol].Value, 64); err == nil {
+				data.Labels = append(data.Labels, label)
+				data.Values = append(data.Values, val)
+			}
+		}
+	}
 	return data
 }
 
@@ -531,55 +838,70 @@ type chartData struct {
 	Values []float64
 }
 
-func renderBarChart(data chartData, style lipgloss.Style, accentColor, textColor lipgloss.Color) string {
+func renderBarChart(data chartData, barWidth int, accentColor, textColor lipgloss.Color) string {
 	if len(data.Values) == 0 {
 		return "No data"
 	}
 
 	var b strings.Builder
 	maxVal := maxFloat(data.Values)
-	if maxVal == 0 {
-		maxVal = 1
+	minVal := minFloat(data.Values)
+	if maxVal == minVal {
+		maxVal = minVal + 1
 	}
+	// Support negative values: shift so min is at 0
+	offset := 0.0
+	if minVal < 0 {
+		offset = -minVal
+	}
+	effectiveMax := maxVal + offset
 
-	maxLabelLen := 15
-	barWidth := 40
-
+	const labelW = 14
 	for i, val := range data.Values {
 		if i >= len(data.Labels) {
 			break
 		}
-
 		label := data.Labels[i]
-		if len(label) > maxLabelLen {
-			label = label[:maxLabelLen-2] + ".."
+		if len([]rune(label)) > labelW {
+			label = string([]rune(label)[:labelW-1]) + "…"
 		}
-		labelStr := lipgloss.NewStyle().Foreground(textColor).Width(maxLabelLen).Render(label)
+		labelStr := lipgloss.NewStyle().Foreground(textColor).Width(labelW).Render(label)
 
-		barLen := int(float64(barWidth) * (val / maxVal))
-		if barLen < 0 {
-			barLen = 0
+		filled := int(float64(barWidth) * ((val + offset) / effectiveMax))
+		if filled < 0 {
+			filled = 0
 		}
-		bar := strings.Repeat("█", barLen)
-		barStr := lipgloss.NewStyle().Foreground(accentColor).Render(bar)
-		valStr := lipgloss.NewStyle().Foreground(textColor).Render(fmt.Sprintf(" %.1f", val))
+		if filled > barWidth {
+			filled = barWidth
+		}
+		empty := barWidth - filled
 
-		b.WriteString(labelStr + " │ " + barStr + valStr + "\n")
+		barColor := accentColor
+		if val < 0 {
+			barColor = lipgloss.Color("#ff6b6b")
+		}
+		bar := lipgloss.NewStyle().Foreground(barColor).Render(strings.Repeat("█", filled)) +
+			strings.Repeat("░", empty)
+		valStr := lipgloss.NewStyle().Foreground(textColor).Render(fmt.Sprintf(" %7s", formatStatNum(val)))
+
+		b.WriteString("  " + labelStr + " │" + bar + valStr + "\n")
 	}
-
-	b.WriteString(strings.Repeat(" ", maxLabelLen) + " └" + strings.Repeat("─", barWidth+2) + "\n")
-	b.WriteString(strings.Repeat(" ", maxLabelLen) + "  0" + strings.Repeat(" ", barWidth-10) + fmt.Sprintf("%.1f", maxVal))
+	b.WriteString("  " + strings.Repeat(" ", labelW) + " └" + strings.Repeat("─", barWidth) + "\n")
+	b.WriteString("  " + strings.Repeat(" ", labelW) + "   " +
+		lipgloss.NewStyle().Foreground(textColor).Render(formatStatNum(minVal)) +
+		strings.Repeat(" ", barWidth/2-4) +
+		lipgloss.NewStyle().Foreground(textColor).Render(formatStatNum(maxVal)))
 
 	return b.String()
 }
 
-func renderLineChart(data chartData, style lipgloss.Style, accentColor, textColor lipgloss.Color) string {
+func renderLineChart(data chartData, width, height int, accentColor, textColor lipgloss.Color) string {
 	if len(data.Values) == 0 {
 		return "No data"
 	}
-
-	height, width := 12, 50
-	var b strings.Builder
+	if len(data.Values) == 1 {
+		return renderBarChart(data, width, accentColor, textColor)
+	}
 
 	minVal := minFloat(data.Values)
 	maxVal := maxFloat(data.Values)
@@ -587,6 +909,7 @@ func renderLineChart(data chartData, style lipgloss.Style, accentColor, textColo
 		maxVal = minVal + 1
 	}
 
+	// Build a grid of runes
 	grid := make([][]rune, height)
 	for i := range grid {
 		grid[i] = make([]rune, width)
@@ -595,36 +918,84 @@ func renderLineChart(data chartData, style lipgloss.Style, accentColor, textColo
 		}
 	}
 
+	// Map each value to (x,y) and draw connecting segments
+	points := make([][2]int, len(data.Values))
 	for i, val := range data.Values {
 		x := int(float64(i) * float64(width-1) / float64(len(data.Values)-1))
-		if x >= width {
-			x = width - 1
-		}
+		x = ui.Min(x, width-1)
 		normalized := (val - minVal) / (maxVal - minVal)
 		y := height - 1 - int(normalized*float64(height-1))
-		if y < 0 {
-			y = 0
-		}
-		if y >= height {
-			y = height - 1
-		}
-		grid[y][x] = '●'
+		y = ui.Max(0, ui.Min(y, height-1))
+		points[i] = [2]int{x, y}
 	}
 
+	// Draw connecting lines between adjacent points using Bresenham
+	for i := 0; i < len(points)-1; i++ {
+		x0, y0 := points[i][0], points[i][1]
+		x1, y1 := points[i+1][0], points[i+1][1]
+		dx := x1 - x0
+		if dx < 0 {
+			dx = -dx
+		}
+		dy := y1 - y0
+		if dy < 0 {
+			dy = -dy
+		}
+		sx := 1
+		if x0 > x1 {
+			sx = -1
+		}
+		sy := 1
+		if y0 > y1 {
+			sy = -1
+		}
+		err := dx - dy
+		for {
+			if x0 >= 0 && x0 < width && y0 >= 0 && y0 < height {
+				if grid[y0][x0] == ' ' {
+					grid[y0][x0] = '·'
+				}
+			}
+			if x0 == x1 && y0 == y1 {
+				break
+			}
+			e2 := 2 * err
+			if e2 > -dy {
+				err -= dy
+				x0 += sx
+			}
+			if e2 < dx {
+				err += dx
+				y0 += sy
+			}
+		}
+	}
+	// Draw data points on top
+	for _, p := range points {
+		if p[0] >= 0 && p[0] < width && p[1] >= 0 && p[1] < height {
+			grid[p[1]][p[0]] = '●'
+		}
+	}
+
+	var b strings.Builder
 	for i, row := range grid {
-		for _, char := range row {
-			if char == '●' {
-				b.WriteString(lipgloss.NewStyle().Foreground(accentColor).Render(string(char)))
-			} else {
+		yVal := maxVal - (float64(i)/float64(height-1))*(maxVal-minVal)
+		yLabel := lipgloss.NewStyle().Foreground(textColor).Width(8).Align(lipgloss.Right).
+			Render(formatStatNum(yVal))
+		b.WriteString("  " + yLabel + " │")
+		for _, ch := range row {
+			switch ch {
+			case '●':
+				b.WriteString(lipgloss.NewStyle().Foreground(accentColor).Bold(true).Render("●"))
+			case '·':
+				b.WriteString(lipgloss.NewStyle().Foreground(accentColor).Render("·"))
+			default:
 				b.WriteString(" ")
 			}
 		}
-		if i%3 == 0 {
-			val := maxVal - (float64(i)/float64(height-1))*(maxVal-minVal)
-			b.WriteString(lipgloss.NewStyle().Foreground(textColor).Render(fmt.Sprintf(" %.1f", val)))
-		}
 		b.WriteString("\n")
 	}
+	b.WriteString("  " + strings.Repeat(" ", 8) + " └" + strings.Repeat("─", width) + "\n")
 
 	return b.String()
 }
@@ -657,7 +1028,7 @@ func renderSparkline(data chartData, accentColor lipgloss.Color) string {
 	return lipgloss.NewStyle().Foreground(accentColor).Render(b.String())
 }
 
-func renderPieChart(data chartData, style lipgloss.Style, colors []lipgloss.Color, textColor lipgloss.Color) string {
+func renderPieChart(data chartData, colors []lipgloss.Color, textColor lipgloss.Color) string {
 	if len(data.Values) == 0 {
 		return "No data"
 	}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -16,27 +16,32 @@ const (
 
 // Styles holds all lipgloss styles for the UI
 type Styles struct {
-	Title           lipgloss.Style
-	Header          lipgloss.Style
-	HeaderHighlight lipgloss.Style
-	Cell            lipgloss.Style
-	SelectedCell    lipgloss.Style
-	RowHighlight    lipgloss.Style
-	ColHighlight    lipgloss.Style
-	SearchMatch     lipgloss.Style
-	RowNum          lipgloss.Style
-	SelectedRowNum  lipgloss.Style
-	StatusBar       lipgloss.Style
-	SearchBar       lipgloss.Style
-	SearchPrompt    lipgloss.Style
-	Modal           lipgloss.Style
-	ModalTitle      lipgloss.Style
-	ModalContent    lipgloss.Style
-	ModalKey        lipgloss.Style
-	ModalValue      lipgloss.Style
-	Help            lipgloss.Style
-	FormulaBar      lipgloss.Style
-	Separator       lipgloss.Style
+	Title            lipgloss.Style
+	Header           lipgloss.Style
+	HeaderHighlight  lipgloss.Style
+	Cell             lipgloss.Style
+	NumberCell       lipgloss.Style
+	FormulaCell      lipgloss.Style
+	SelectedCell     lipgloss.Style
+	SelectionCell    lipgloss.Style
+	FrozenHeaderCell lipgloss.Style
+	FrozenDivider    lipgloss.Style
+	RowHighlight     lipgloss.Style
+	ColHighlight     lipgloss.Style
+	SearchMatch      lipgloss.Style
+	RowNum           lipgloss.Style
+	SelectedRowNum   lipgloss.Style
+	StatusBar        lipgloss.Style
+	SearchBar        lipgloss.Style
+	SearchPrompt     lipgloss.Style
+	Modal            lipgloss.Style
+	ModalTitle       lipgloss.Style
+	ModalContent     lipgloss.Style
+	ModalKey         lipgloss.Style
+	ModalValue       lipgloss.Style
+	Help             lipgloss.Style
+	FormulaBar       lipgloss.Style
+	Separator        lipgloss.Style
 }
 
 // InitStyles creates and returns styles based on current theme
@@ -68,11 +73,33 @@ func InitStyles() *Styles {
 			Foreground(t.Text).
 			Width(MinCellWidth),
 
+		NumberCell: lipgloss.NewStyle().
+			Foreground(t.Accent).
+			Width(MinCellWidth),
+
+		FormulaCell: lipgloss.NewStyle().
+			Foreground(t.Secondary).
+			Width(MinCellWidth),
+
 		SelectedCell: lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#000000")).
 			Background(t.CellHighlight).
 			Bold(true).
 			Width(MinCellWidth),
+
+		SelectionCell: lipgloss.NewStyle().
+			Foreground(t.Background).
+			Background(t.Primary).
+			Width(MinCellWidth),
+
+		FrozenHeaderCell: lipgloss.NewStyle().
+			Foreground(t.Primary).
+			Background(t.Border).
+			Bold(true).
+			Width(MinCellWidth),
+
+		FrozenDivider: lipgloss.NewStyle().
+			Foreground(t.Primary),
 
 		RowHighlight: lipgloss.NewStyle().
 			Foreground(t.Text).

--- a/main.go
+++ b/main.go
@@ -13,10 +13,10 @@ import (
 var version = "2.1.0"
 
 var (
-	showVersion   = flag.Bool("version", false, "Show version information")
-	showHelp      = new(bool)
-	themeName     = flag.String("theme", "catppuccin", "Set the color theme")
-	csvDelimiter  = flag.String("delimiter", "", "CSV delimiter character (e.g. ';', '\\t', '|'). Auto-detected if not set.")
+	showVersion  = flag.Bool("version", false, "Show version information")
+	showHelp     = new(bool)
+	themeName    = flag.String("theme", "catppuccin", "Set the color theme")
+	csvDelimiter = flag.String("delimiter", "", "CSV delimiter character (e.g. ';', '\\t', '|'). Auto-detected if not set.")
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-var version = "2.0.2"
+var version = "2.1.0"
 
 var (
 	showVersion   = flag.Bool("version", false, "Show version information")
@@ -120,12 +120,16 @@ func printHelp() {
 	fmt.Println("  vex data.tsv -d '\\t'")
 	fmt.Println("  vex sales.xlsx -t tokyo-night")
 	fmt.Println("\nKEYBOARD SHORTCUTS:")
-	fmt.Println("  Navigation:  ↑↓←→ / hjkl, PgUp/PgDn, Home/End")
+	fmt.Println("  Navigation:  ↑↓←→ / hjkl, PgUp/PgDn, Home/End, gg/G")
 	fmt.Println("  Sheets:      Tab / Shift+Tab")
-	fmt.Println("  Search:      / (search), n (next), N (prev)")
-	fmt.Println("  Actions:     Enter (details), Ctrl+G (jump), c (copy)")
-	fmt.Println("  Data viz:    V (select range), v (visualize)")
-	fmt.Println("  Other:       e (export), t (theme), f (formulas), ? (help), q (quit)")
+	fmt.Println("  Search:      / (search), n/N (next/prev), Esc (clear)")
+	fmt.Println("  Filter:      f (filter rows), Esc (clear filter)")
+	fmt.Println("  Sort:        s (asc), S (desc), u (unsort/restore)")
+	fmt.Println("  Data:        W (data profile), Ctrl+R (freeze header)")
+	fmt.Println("  Edit:        i (edit), x (delete), dd (row), dc (col)")
+	fmt.Println("  Copy/paste:  c (cell), C (row), p (paste)")
+	fmt.Println("  Visualize:   V (select), v (chart), 1-4 (chart type)")
+	fmt.Println("  File:        Ctrl+S (save), e (export), q (quit)")
 	fmt.Println("\nFor more information, visit: https://github.com/CodeOne45/vex-tui")
 }
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -31,6 +31,8 @@ const (
 	ModeSelectRange
 	ModeEdit
 	ModeSaveAs
+	ModeFilter
+	ModeDataProfile
 )
 
 // StatusMsg represents a status message with type


### PR DESCRIPTION
## [2.1.0] - 2026-04-17

### Added

#### Row Filter (`f`)
- Press `f` to filter rows on the current column or all columns (Tab toggles scope)
- Supports plain text (contains), `>`, `<`, `>=`, `<=`, `=` expressions for numeric and exact-match comparisons
- Active filter shown in the title bar as `▾ <expr>`; **Esc** clears it without touching the underlying data

#### Data Profile (`W`)
- New modal showing a per-column breakdown: detected type (number / text / mixed), non-null count, null count
- Numeric columns show Σ / avg / min / max inline; text columns show unique count and top sample values
- Highlights the column currently under the cursor

#### Sort Columns (`s` / `S` / `u`)
- `s` sorts the current column ascending, `S` descending
- `u` restores the original row order (pre-sort state is saved in memory)
- Sort indicator shown in the column header and title bar; freeze-header aware

#### Freeze Header Row (`Ctrl+R`)
- Toggles the first row pinned at all times while scrolling
- A divider line separates the frozen row from scrollable data
- `⌶` indicator in title bar; sort respects the frozen header

#### Live Column Statistics
- When the cursor is on any numeric column, the status bar automatically shows Σ / avg / min / max / n
- No selection needed; updates as you navigate

#### Chart PNG Export (`p` in chart view)
- Press `p` inside the chart modal to export the current chart as a beautiful PNG via [`freeze`](https://github.com/charmbracelet/freeze)
- Output file is `<filename>-chart.png` saved next to the source file
- If `freeze` is not on PATH the binary is located across all common Homebrew and Linux install paths automatically
- If still not found, shows the exact install command as a status bar hint

#### CSV Delimiter Auto-Detection + CLI Flag
- Vex reads the first line of every CSV and picks the best delimiter from `,` `;` `\t` `|`
- New `-d` / `--delimiter` flag for explicit override: `vex data.csv -d ';'`, `vex data.tsv -d '\t'`

### Changed

#### UI / UX
- **Cell type coloring**: numbers render in accent color, formulas in secondary color, text in default — no configuration needed
- **Status bar redesign**: left cluster (cell ref + dimensions + mode flags), middle cluster (column stats or selection size), right cluster (search + status message)
- **Title bar**: `●` modified indicator appears immediately on first edit; freeze / sort / filter state shown as compact glyphs
- **Selection highlight**: uses primary color background, much more visible than before
- **Responsive modals**: theme picker and chart modal now scale to terminal width/height instead of hardcoded sizes
- **Chart bar chart**: supports negative values (shown in red), `░` unfilled track, cleaner value labels
- **Chart line chart**: Bresenham algorithm draws actual connecting lines (`·`) between data points (`●`)
- **Chart data extraction**: auto-detects label vs value columns — works with or without a leading text column
- **Chart type tabs**: rendered as proper tab buttons instead of a plain list

#### Keybinding Changes
- `f` — now opens row filter (was: toggle formula display)
- `ctrl+f` — toggle formula display (moved from `f`)
- `W` — data profile
- `s` / `S` / `u` — sort asc / desc / unsort
- `ctrl+r` — freeze header

#### Release Workflow
- GoReleaser config: grouped changelog, `test` stanza in Homebrew formula, Scoop bucket support
- `Makefile`: `make tag VER=v2.1.0` tags and pushes, triggering the full CI/release pipeline; `make snapshot` for local multi-platform builds

### Fixed

- **Esc cancels selection**: pressing Esc in normal mode while a range is selected now cancels it (previously Esc only cleared search)
- **Freeze binary lookup**: `freeze` is located across PATH, all Homebrew symlink paths, and the Cellar directly — fixing "not found" errors when the Homebrew symlink is broken
